### PR TITLE
call delegate `#getService()` when looking up single service

### DIFF
--- a/src/main/java/javax/money/spi/Bootstrap.java
+++ b/src/main/java/javax/money/spi/Bootstrap.java
@@ -111,18 +111,14 @@ public final class Bootstrap {
     }
 
     /**
-     * Delegate method for {@link ServiceProvider#getServices(Class)}.
+     * Delegate method for {@link ServiceProvider#getService(Class)}.
      *
      * @param serviceType the service type.
      * @return the service found, or {@code null}.
      * @see ServiceProvider#getServices(Class)
      */
     public static <T> T getService(Class<T> serviceType) {
-        List<T> services = getServiceProvider().getServices(serviceType);
-		return services
-				.stream()
-                .findFirst()
-                .orElse(null);
+        return getServiceProvider().getService(serviceType);
     }
 
 }


### PR DESCRIPTION
as classes implementing `ServiceProvider` may define their own
custom behaviour, let the `ServiceProvider` instance itself fetch a single
service by name instead of using an own standard strategy (using the first one
returned by `#getServices(Class)`)

this way it is prevented that a `ServiceProvider` must load all services of the class
even if they are not generellay needed (including all side effects e.g. loading data
from remote services)